### PR TITLE
ES basic auth and context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ para.es.sign_requests_to_aws = false
 para.es.aws_region = "eu-west-1"
 para.es.fail_on_indexing_errors = false
 para.es.track_total_hits = 10000
+# if login and password are filled then add for each request
+# the Authorization header with basic auth
+para.es.basic_auth_login = ""
+para.es.basic_auth_password = ""
 
 # asynchronous settings
 para.es.async_enabled = false

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ para.es.transportclient_port = 9300
 para.es.restclient_scheme = "http"
 para.es.restclient_host = "localhost"
 para.es.restclient_port = 9200
+# context path of elasticsearch e.g. /es
+para.es.restclient_context_path = ""
 para.es.sign_requests_to_aws = false
 para.es.aws_region = "eu-west-1"
 para.es.fail_on_indexing_errors = false

--- a/src/main/java/com/erudika/para/search/ElasticSearchUtils.java
+++ b/src/main/java/com/erudika/para/search/ElasticSearchUtils.java
@@ -233,6 +233,11 @@ public final class ElasticSearchUtils {
 		HttpHost host = new HttpHost(esHost, esPort, esScheme);
 		RestClientBuilder clientBuilder = RestClient.builder(host);
 
+		String esPrefix = Config.getConfigParam("es.restclient_context_path", "");
+		if (StringUtils.isNotEmpty(esPrefix)) {
+			clientBuilder.setPathPrefix(esPrefix);
+		}
+
 		List<RestClientBuilder.HttpClientConfigCallback> configurationCallbacks = new ArrayList<>();
 
 		if (signRequests) {


### PR DESCRIPTION
Add two optional configurations to configure connection to ElasticSearch

## Context path
new option `para.es.restclient_prefix` to allow access to http://localhost:9200/es/
Default to empty string

## Basic auth
I hesitated to define a header but the Elastic documention states using [CrendentialsProvider](https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_basic_authentication.html#_basic_authentication) so I followed this recommendation.

In order to pass a second `HttpClientConfigCallback` whereas the `RestClientBuilder` supports only one I chose to:
- always create a customizer for authentication (create noop customizer if not configured)
- store customizers in a _List_
- add the existing _getAWSRequestSigningInterceptor_ customizer to his list if activated
- register a unique customizer that applies all in sequence (composite pattern although)

I did not add integration tests but validated this usage on internal component (@societe-generale).