### PR TITLE
Fix broken shaded JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
-							<minimizeJar>true</minimizeJar>
+							<minimizeJar>false</minimizeJar>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />


### PR DESCRIPTION
Since this plugin has dependencies that use SPI (Service Provider Interface), the minimizeJar option in maven-shade-plugin should not be true. JAR minimization does not work properly for class referred to by reflection and should be used with caution.